### PR TITLE
Update Nginx images to use builds from official repository

### DIFF
--- a/_variables.source
+++ b/_variables.source
@@ -16,9 +16,9 @@ PHP_BASE_TAG=latest
 NGINX_BASE_TAG=latest
 NODE_BASE_TAG=latest
 
-# Support images that does not contain any project-code, thus we track eg. 
+# Support images that does not contain any project-code, thus we track eg.
 # configuration-changes and general software updates via a "build" tag.
-ADMIN_NGINX_BUILD_TAG=reload-0.1.0
+ADMIN_NGINX_BUILD_TAG=reload-0.2.0
 
 # All images has a "build-tag", som have a "source-tag". A Source-tag references
 # the version of the project the image hosts (eg. elasticsearch).

--- a/images/admin-nginx/Dockerfile
+++ b/images/admin-nginx/Dockerfile
@@ -6,4 +6,4 @@ FROM ${os2display_image_repository}/os2display-nginx-base
 
 WORKDIR /var/www/admin
 
-COPY config/admin.conf /etc/nginx/sites-enabled/
+COPY config/admin.conf /etc/nginx/conf.d/

--- a/images/nginx-base/Dockerfile
+++ b/images/nginx-base/Dockerfile
@@ -2,13 +2,22 @@ ARG os2display_image_repository=os2display
 
 FROM ${os2display_image_repository}/os2display-docker-base
 
+# Allow installations of prebuilt Ubuntu packages from official NGINX repository
 RUN apt-get update
+RUN apt-get install -y gnupg
+RUN curl https://nginx.org/keys/nginx_signing.key -o nginx_signing.key
+RUN apt-key add nginx_signing.key
+RUN printf "deb https://nginx.org/packages/ubuntu/ bionic nginx\ndeb-src https://nginx.org/packages/ubuntu/ bionic nginx" > /etc/apt/sources.list
+RUN apt-get update
+
+# Now we can install NGINX
 RUN apt-get install -y --no-install-recommends nginx
+
 # Clean out temporary files, notices that you have to a squash to get any gains.
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Disable the default site which will make our site the default.
-RUN unlink /etc/nginx/sites-enabled/default
+RUN unlink /etc/nginx/conf.d/default.conf
 
 # Following section is taken from the official nginx images
 

--- a/images/screen/Dockerfile
+++ b/images/screen/Dockerfile
@@ -17,7 +17,7 @@ FROM ${os2display_image_repository}/os2display-nginx-base
 
 WORKDIR /var/www/screen
 
-COPY config/screen.conf /etc/nginx/sites-enabled/
+COPY config/screen.conf /etc/nginx/conf.d/
 
 COPY --from=fetcher /var/www/screen /var/www/screen
 COPY config/config.js /var/www/screen/app/config.js


### PR DESCRIPTION
We use Ubuntu 18.04 as our base distribution of our images. It uses
Nginx 1.14. Several versions containing [fixes for security 
vulnerabilities](http://nginx.org/en/security_advisories.html) have been released since and we want to use one of 
these.

Updating to a newer Ubuntu release will lead to changes to many
packages. Instead we update our Nginx base image to install Nginx
from the official repository.

The official repository has two versions: Mainline and stable. [Stable
is recommended for compatibility with other older packages](https://www.nginx.com/blog/nginx-1-6-1-7-released/#Which-Version-Should-I-Use) so we opt
for that. This currently gives us version 1.18.0.

Bump the build tag to show the change. Note that no new builds have been released yet.

Apparently newer versions of Nginx no longer includes configuration
in /etc/nginx/sites-enabled by default. Instead /etc/nginx/conf.d is
used. Update Docker files to place our custom configuration there
instead.