### PR TITLE
Re-configure mysqldump to perform its dump in a single transaction.

### DIFF
--- a/_variables.source
+++ b/_variables.source
@@ -16,7 +16,7 @@ PHP_BASE_TAG=latest
 NGINX_BASE_TAG=latest
 NODE_BASE_TAG=latest
 
-# Support images that does not contain any project-code, thus we track eg. 
+# Support images that does not contain any project-code, thus we track eg.
 # configuration-changes and general software updates via a "build" tag.
 ADMIN_NGINX_BUILD_TAG=reload-0.1.0
 
@@ -53,7 +53,7 @@ REDIS_SOURCE_TAG=4.0.9
 REDIS_BUILD_TAG=reload-0.1.0
 
 MARIADB_SOURCE_TAG=10.3
-ADMIN_DB_BACKUP_BUILD_TAG=reload-1.0.0
+ADMIN_DB_BACKUP_BUILD_TAG=reload-1.1.0
 
 # This tag is used to determine which tag to build when make build-release is
 # run. It is also used by docker-compose when in release mode (see reset-release


### PR DESCRIPTION
Without this mysqldump would attempt to get a lock on all tables in the database.

Using a single transaction for dumping the data is safe as innodb ensures read-consistency within an transaction.

I expect to do a manual release of the image after merge (currently the only way to do it).

Issue: https://reload.atlassian.net/browse/OSD-107
